### PR TITLE
perf: Optimise dedication average query and add composite index

### DIFF
--- a/classes/lib/utils.php
+++ b/classes/lib/utils.php
@@ -309,14 +309,19 @@ class utils {
         $roleids = array_map('intval', explode(',', $dedicationrolespecify));
         list($roleidsql, $params_roleids) = $DB->get_in_or_equal($roleids, SQL_PARAMS_NAMED);
 
+        // Look up the course context ID once — avoids joining {course} and {context} tables.
+        $contextid = \context_course::instance($courseid)->id;
+
         $params = [
             'courseid' => $courseid,
+            'contextid' => $contextid,
         ];
 
         $params = array_merge($params, $params_roleids);
 
+        $sqlextra = '';
         if (!empty($duration)) {
-            $sqlextra = " AND timestart > :since";
+            $sqlextra = " AND bd.timestart > :since";
             $params['since'] = time() - $duration;
         }
 
@@ -326,52 +331,32 @@ class utils {
 
             list($joinsql, $wheresql, $filterparams) = local_ace_generate_filter_sql($SESSION->local_ace_filtervalues);
 
-            $sqltotal = "SELECT SUM(bd.timespent)
+            // Filter path needs {user} u for filter JOINs that reference u.id / u.idnumber.
+            $sql = "SELECT SUM(bd.timespent) AS total, COUNT(DISTINCT bd.userid) AS usercount
                 FROM {block_dedication} bd
                 JOIN {user} u ON u.id = bd.userid
-                JOIN {role_assignments} ra ON ra.userid = u.id
-                JOIN {course} c ON c.id = bd.courseid
-                JOIN {context} ctx ON ctx.id = ra.contextid AND ctx.instanceid = bd.courseid
-                ".implode(" ", $joinsql)."
-                WHERE c.id = :courseid".$sqlextra."
-                AND ra.roleid ".$roleidsql." ".implode(" ", $wheresql);
-
-            $sqlusers = "SELECT COUNT(DISTINCT bd.userid)
-                FROM {block_dedication} bd
-                JOIN {user} u ON u.id = bd.userid
-                JOIN {role_assignments} ra ON ra.userid = u.id
-                JOIN {course} c ON c.id = bd.courseid
-                JOIN {context} ctx ON ctx.id = ra.contextid AND ctx.instanceid = bd.courseid
-                ".implode(" ", $joinsql)."
-                WHERE c.id = :courseid".$sqlextra."
-                AND ra.roleid ".$roleidsql." ".implode(" ", $wheresql);
+                JOIN {role_assignments} ra ON ra.contextid = :contextid AND ra.userid = bd.userid
+                " . implode(" ", $joinsql) . "
+                WHERE bd.courseid = :courseid" . $sqlextra . "
+                AND ra.roleid " . $roleidsql . " " . implode(" ", $wheresql);
 
             $params = array_merge($params, $filterparams);
 
         } else {
 
-            $sqltotal = "SELECT SUM(bd.timespent)
+            // Unfiltered path — no need for {user}, {course}, or {context} table JOINs.
+            // block_dedication already has courseid, and we looked up contextid above.
+            $sql = "SELECT SUM(bd.timespent) AS total, COUNT(DISTINCT bd.userid) AS usercount
                 FROM {block_dedication} bd
-                JOIN {user} u ON u.id = bd.userid
-                JOIN {role_assignments} ra ON ra.userid = u.id
-                JOIN {course} c ON c.id = bd.courseid
-                JOIN {context} ctx ON ctx.id = ra.contextid AND ctx.instanceid = bd.courseid
-                WHERE c.id = :courseid".$sqlextra."
-                AND ra.roleid ".$roleidsql;
-
-            $sqlusers = "SELECT COUNT(DISTINCT bd.userid)
-                FROM {block_dedication} bd
-                JOIN {user} u ON u.id = bd.userid
-                JOIN {role_assignments} ra ON ra.userid = u.id
-                JOIN {course} c ON c.id = bd.courseid
-                JOIN {context} ctx ON ctx.id = ra.contextid AND ctx.instanceid = bd.courseid
-                WHERE c.id = :courseid".$sqlextra."
-                AND ra.roleid ".$roleidsql;
+                JOIN {role_assignments} ra ON ra.contextid = :contextid AND ra.userid = bd.userid
+                WHERE bd.courseid = :courseid" . $sqlextra . "
+                AND ra.roleid " . $roleidsql;
 
         }
 
-        $totaldedication = $DB->get_field_sql($sqltotal, $params);
-        $totalusers = $DB->get_field_sql($sqlusers, $params);
+        $result = $DB->get_record_sql($sql, $params);
+        $totaldedication = $result->total ?? 0;
+        $totalusers = $result->usercount ?? 0;
 
         // Get the role names used to calculate the average dedicated time for the course.
         $rolequery = "SELECT * FROM {role} WHERE id ".$roleidsql;

--- a/db/install.xml
+++ b/db/install.xml
@@ -17,6 +17,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="block_dedication" UNIQUE="false" FIELDS="userid, courseid"/>
+        <INDEX NAME="blocdedi_coutimuse_ix" UNIQUE="false" FIELDS="courseid, timestart, userid" COMMENT="Optimise dedication average queries filtering by courseid and timestart range"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -59,5 +59,18 @@ function xmldb_block_dedication_upgrade($oldversion, $block) {
         upgrade_block_savepoint(true, 2022122100, 'dedication');
     }
 
+    if ($oldversion < 2026041700) {
+        // Add composite index on block_dedication(courseid, timestart, userid) to optimise
+        // the dedication average queries which filter by courseid and timestart range.
+        // The existing index (userid, courseid) is wrong order for these queries.
+        $table = new xmldb_table('block_dedication');
+        $index = new xmldb_index('blocdedi_coutimuse_ix', XMLDB_INDEX_NOTUNIQUE, ['courseid', 'timestart', 'userid']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        upgrade_block_savepoint(true, 2026041700, 'dedication');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_dedication';
-$plugin->release = 2024072200;
-$plugin->version = 2024072200;
+$plugin->release = 2024072201;
+$plugin->version = 2024072201;
 $plugin->requires = 2024042200; // Requires 4.4.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [404, 404];
+$plugin->supported = [404, 405];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_dedication';
-$plugin->release = 2024072201;
-$plugin->version = 2024072201;
+$plugin->release = 2026041700;
+$plugin->version = 2026041700;
 $plugin->requires = 2024042200; // Requires 4.4.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
## Summary

  Performance optimisation for the dedication average calculation that runs on every dashboard page load.

  - **Merged 2 separate queries into 1:** Combined `SUM(timespent)` and `COUNT(DISTINCT userid)` into a single query with one database round-trip
  - **Eliminated 3 redundant JOINs:** Removed unnecessary joins to `{user}`, `{course}`, and `{context}` tables — only `{role_assignments}` JOIN retained
  - **Context lookup via Moodle API:** Uses `context_course::instance($courseid)` (Moodle-cached) instead of joining the context table in SQL
  - **Composite index:** Added index on `block_dedication(courseid, timestart, userid)` to optimise queries filtering by courseid and timestart range — the existing
  `(userid, courseid)` index was wrong column order for these queries
  - Filtered path (ACE cohort filters active) retains `{user}` JOIN for filter references but still eliminates `{course}` and `{context}`
  - Version bump to `2026041700`, `supported = [404, 405]`