### PR TITLE
fix: Migrate filter SESSION read to filter_manager

### DIFF
--- a/classes/lib/utils.php
+++ b/classes/lib/utils.php
@@ -23,6 +23,9 @@
  */
 
 namespace block_dedication\lib;
+
+use local_ace\local\filter_manager;
+
 /**
  * Utils helper class.
  */
@@ -325,11 +328,11 @@ class utils {
             $params['since'] = time() - $duration;
         }
 
-        if (!empty($SESSION->local_ace_filtervalues) && $filter && file_exists($CFG->dirroot . '/local/ace/locallib.php')) {
+        if (filter_manager::has_active_filters() && $filter && file_exists($CFG->dirroot . '/local/ace/locallib.php')) {
 
             require_once($CFG->dirroot . '/local/ace/locallib.php');
 
-            list($joinsql, $wheresql, $filterparams) = local_ace_generate_filter_sql($SESSION->local_ace_filtervalues);
+            list($joinsql, $wheresql, $filterparams) = filter_manager::get_filter_sql();
 
             // Filter path needs {user} u for filter JOINs that reference u.id / u.idnumber.
             $sql = "SELECT SUM(bd.timespent) AS total, COUNT(DISTINCT bd.userid) AS usercount


### PR DESCRIPTION
## Summary

  Replaces direct `$SESSION->local_ace_filtervalues` access with `filter_manager` calls in the dedication block's utility class.

  - **Centralised read:** `utils.php` now uses `filter_manager::has_active_filters()` and `filter_manager::get_filter_sql()` instead of checking and consuming the session key directly

  ## Changes (1 file, 1 commit)

  | Commit | Scope |
  |--------|-------|
  | `f6cead0` | Replace SESSION read with `filter_manager` |

  ## Paired PRs

  This is a cross-plugin refactor. The following submodule PRs must be merged together:

  - **local/ace** `fix/ADO_#178944` — New `filter_manager` class, migrate all SESSION readers, SQL safety hardening, bug fixes (7 commits)
  - **blocks/report_filter** `fix/ADO_#178944` — Consolidate filter writes via filter_manager; filter persistence on page refresh and CTA positioning (2 commits)
  - **blocks/ace** `fix/ADO_#178944` — Remove direct SESSION filter access for bidirectional persistence (2 commits)