### PR TITLE
refactor: compact time format in format_dedication()

### DIFF
--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -89,20 +89,17 @@ class utils {
         }
         $totalsecs = abs($totalsecs);
 
-        $hours = floor($totalsecs / HOURSECS);
-        $mins = floor(($totalsecs - ($hours * HOURSECS)) / MINSECS);
-
-        $sh = ($hours == 1) ? get_string('hour') : get_string('hours');
-        $sm = ($mins == 1) ? get_string('min') : get_string('mins');
+        $hours = (int) floor($totalsecs / HOURSECS);
+        $mins = (int) floor(($totalsecs - ($hours * HOURSECS)) / MINSECS);
 
         if ($hours && $mins) {
-            return $hours . ' ' . $sh . ' ' . $mins . ' ' . $sm;
+            return $hours . 'h ' . $mins . 'm';
         }
         if ($hours) {
-            return $hours . ' ' . $sh;
+            return $hours . 'h';
         }
         if ($mins) {
-            return $mins . ' ' . $sm;
+            return $mins . 'm';
         }
         return get_string('lessthanaminute', 'block_dedication');
     }


### PR DESCRIPTION
Change output from verbose "1 hour 39 mins" to compact "1h 39m", aligning with ACE graph tooltip convention.