### PR TITLE
chore: document (userid, courseid) index and bump version

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -16,7 +16,7 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
       <INDEXES>
-        <INDEX NAME="block_dedication" UNIQUE="false" FIELDS="userid, courseid"/>
+        <INDEX NAME="block_dedication" UNIQUE="false" FIELDS="userid, courseid" COMMENT="Per-user per-course dedication lookups"/>
         <INDEX NAME="blocdedi_coutimuse_ix" UNIQUE="false" FIELDS="courseid, timestart, userid" COMMENT="Optimise dedication average queries filtering by courseid and timestart range"/>
       </INDEXES>
     </TABLE>

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_dedication';
-$plugin->release = 2026041700;
-$plugin->version = 2026041700;
+$plugin->release = 2026062200;
+$plugin->version = 2026062200;
 $plugin->requires = 2024042200; // Requires 4.4.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
## Summary

Promotes the `feat/ADO_#180714` work from `staging` to `main`. Documentation and version bump only — no functional change.

## Changes

- Add an XMLDB `COMMENT` to the `(userid, courseid)` index, describing its role in per-user, per-course dedication lookups.
- Bump `$plugin->version` and `$plugin->release` to `2026062200`.