### PR TITLE
refactor: move api facade out of external into classes root

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace block_dedication\external;
+namespace block_dedication;
 
 use block_dedication\local\utils;
 

--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -291,10 +291,10 @@ class utils {
         }
 
         $acefilteravailable = $filter
-            && class_exists('local_ace\external\filter_api')
-            && \local_ace\external\filter_api::has_active_filters($courseid);
+            && class_exists('local_ace\filter_api')
+            && \local_ace\filter_api::has_active_filters($courseid);
         if ($acefilteravailable) {
-            [$joinsql, $wheresql, $filterparams] = \local_ace\external\filter_api::get_filter_sql('studentattributes', $courseid);
+            [$joinsql, $wheresql, $filterparams] = \local_ace\filter_api::get_filter_sql('studentattributes', $courseid);
 
             // Filter path needs {user} u for filter JOINs that reference u.id / u.idnumber.
             $sql = "SELECT SUM(bd.timespent) AS total, COUNT(DISTINCT bd.userid) AS usercount


### PR DESCRIPTION
block_dedication\api is a public cross-plugin facade consumed by local_ace, not a web-service function. Move classes/external/api.php to classes/api.php (namespace block_dedication) and re-point the \local_ace\filter_api caller in classes/local/utils.php. No behaviour change.