### PR TITLE
refactor: move the api facade out of classes/external into the classes root

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace block_dedication\external;
+namespace block_dedication;
 
 use block_dedication\local\utils;
 

--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -291,10 +291,10 @@ class utils {
         }
 
         $acefilteravailable = $filter
-            && class_exists('local_ace\external\filter_api')
-            && \local_ace\external\filter_api::has_active_filters($courseid);
+            && class_exists('local_ace\filter_api')
+            && \local_ace\filter_api::has_active_filters($courseid);
         if ($acefilteravailable) {
-            [$joinsql, $wheresql, $filterparams] = \local_ace\external\filter_api::get_filter_sql('studentattributes', $courseid);
+            [$joinsql, $wheresql, $filterparams] = \local_ace\filter_api::get_filter_sql('studentattributes', $courseid);
 
             // Filter path needs {user} u for filter JOINs that reference u.id / u.idnumber.
             $sql = "SELECT SUM(bd.timespent) AS total, COUNT(DISTINCT bd.userid) AS usercount


### PR DESCRIPTION
1 commit (2026-07-23), part of the suite-wide namespace correction: classes/external is
  for external (web service) function definitions only, so the cross-plugin facade belongs
  in the classes root. classes/external/api.php -> classes/api.php, with the two call sites
  in classes/local/utils.php updated.

  ⚠ No version bump — version.php is unchanged between main and staging. This one moves a
  class file, so the classmap cache must be rebuilt on the PROD server: bump the version
  before merging, otherwise the change lands only after a manual cache purge and any
  in-flight request resolving the old path will fail.

  This plugin has no staging convention of its own (MOODLE_404_STABLE is upstream's branch),
  so confirm main is the intended target here rather than MOODLE_404_STABLE.